### PR TITLE
Website: Fix links to APK

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         </header>
 
         <section id="downloads" class="clearfix">
-          <a href="https://github.com/mudar/SnooZy/raw/master/APK/SnooZy.apk" id="download-apk" class="button"><span>Download .apk</span></a>
+          <a href="https://github.com/mudar/SnooZy/raw/master/APK/SnooZy-release.apk" id="download-apk" class="button"><span>Download .apk</span></a>
           <a href="https://github.com/mudar/SnooZy/zipball/master" id="download-zip" class="button"><span>Download .zip</span></a>
           <a href="https://github.com/mudar/SnooZy" id="view-on-github" class="button"><span>View on GitHub</span></a>
         </section>
@@ -63,7 +63,7 @@ This would drain the battery because of the screen turning on to display the "Ch
 <li><a href="http://snoozy.mudar.ca/">Website</a></li>
 <li><a href="http://snoozy.mudar.ca/privacy.html">Privacy policy</a></li>
 <li><a href="https://github.com/mudar/SnooZy">Source code on GitHub</a>
-<li>Download <a href="https://github.com/mudar/SnooZy/raw/master/APK/SnooZy.apk">.apk</a>, 
+<li>Download <a href="https://github.com/mudar/SnooZy/raw/master/APK/SnooZy-release.apk">.apk</a>, 
  <a href="https://github.com/mudar/SnooZy/zipball/master">.zip</a> or 
  <a href="https://github.com/mudar/SnooZy/tarball/master">.tar.gz</a>
 </li>

--- a/privacy.html
+++ b/privacy.html
@@ -24,7 +24,7 @@
         </header>
 
         <section id="downloads" class="clearfix">
-          <a href="https://github.com/mudar/SnooZy/raw/master/APK/SnooZy.apk" id="download-apk" class="button"><span>Download .apk</span></a>
+          <a href="https://github.com/mudar/SnooZy/raw/master/APK/SnooZy-release.apk" id="download-apk" class="button"><span>Download .apk</span></a>
           <a href="https://github.com/mudar/SnooZy/zipball/master" id="download-zip" class="button"><span>Download .zip</span></a>
           <a href="https://github.com/mudar/SnooZy" id="view-on-github" class="button"><span>View on GitHub</span></a>
         </section>


### PR DESCRIPTION
The website links to a file called `Snoozy.apk`. However, the APK hosted in the repository is called `Snoozy-release.apk`, and therefore the links are currently broken. This pull request updates the links on the website to point to `Snoozy-release.apk`.